### PR TITLE
Update 2023-10-03-ansible-role-rhel_iso_kickstart.md

### DIFF
--- a/_posts/2023-10-03-ansible-role-rhel_iso_kickstart.md
+++ b/_posts/2023-10-03-ansible-role-rhel_iso_kickstart.md
@@ -264,7 +264,7 @@ Example playbook:
           - !vault |
               $ANSIBLE_VAULT;1.1;AES256
               [..]
-    kickstart_password: !vault |
+    kickstart_root_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           [..]
     api_token: !vault |


### PR DESCRIPTION
I spotted a typo in line 267 of the third use case. The role defines the variable `kickstart_root_password` but example uses `kickstart_password`. This PR will fix it.