### PR TITLE
fix: Removing usage of plugin jekyll-last-modified-at

### DIFF
--- a/.github/spellcheck/spellcheck.yml
+++ b/.github/spellcheck/spellcheck.yml
@@ -100,7 +100,7 @@ matrix:
             # author: John and Jane Doe
             # ---
             #
-            - open: '(?s)^(?:title|author):'
+            - open: '(?s)^(?:title|author|last_modified_at):'
               content: '[^\n]+'
               close: '$'
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ group :jekyll_plugins do
   gem 'jekyll-spaceship'
   gem 'jekyll-extract'
   gem 'jekyll-gist'
-  gem 'jekyll-last-modified-at'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,6 @@ GEM
       octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-last-modified-at (1.3.0)
-      jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -220,14 +217,13 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.18.0)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.15)
     public_suffix (4.0.7)
     racc (1.6.2)
     rainbow (3.1.1)
@@ -270,7 +266,6 @@ DEPENDENCIES
   jekyll-extract
   jekyll-feed (~> 0.17)
   jekyll-gist
-  jekyll-last-modified-at
   jekyll-spaceship
   jemoji
   minima (~> 2.5)

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,11 @@ layout: default
         Published: {{ page.date | date: date_format }}
       </time>
       <time class="dt-modified" datetime="{{ page.last_modified_at | date_to_xmlschema }}" itemprop="dateModified">
-        • Last modified: {{ page.last_modified_at | date: "%b %-d, %Y, %H:%M" }}
+        {%- if page.last_modified_at -%}
+        • Last modified: {{ page.last_modified_at | date: date_format }}
+        {%- else -%}
+        • Last modified: {{ page.date | date: date_format }}
+        {%- endif %}
       </time>
       {%- if page.author -%}
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>

--- a/_posts/2023-05-01-debootstrapping-debian.md
+++ b/_posts/2023-05-01-debootstrapping-debian.md
@@ -1,6 +1,7 @@
 ---
 title: Manually installing Debian 11 (Bullseye) with fully encrypted LUKS (besides /boot) using debootstrap
 author: Steffen Scheib
+last_modified_at: 2024-04-01
 ---
 ## Introduction
 
@@ -373,14 +374,14 @@ And will leave us with following logical volumes:
 ```terminal
 root@rescue ~ # lvs
   LV            VG        Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
-  home          vg_system -wi-a-----  4.00g  
-  root          vg_system -wi-a----- 16.00g  
-  swap          vg_system -wi-a----- 16.00g  
-  tmp           vg_system -wi-a-----  4.00g  
-  var           vg_system -wi-a----- 32.00g  
-  var_log       vg_system -wi-a-----  8.00g  
-  var_log_audit vg_system -wi-a-----  2.00g  
-  var_tmp       vg_system -wi-a-----  4.00g  
+  home          vg_system -wi-a-----  4.00g
+  root          vg_system -wi-a----- 16.00g
+  swap          vg_system -wi-a----- 16.00g
+  tmp           vg_system -wi-a-----  4.00g
+  var           vg_system -wi-a----- 32.00g
+  var_log       vg_system -wi-a-----  8.00g
+  var_log_audit vg_system -wi-a-----  2.00g
+  var_tmp       vg_system -wi-a-----  4.00g
 root@rescue ~ #
 ```
 
@@ -388,7 +389,7 @@ root@rescue ~ #
 
 ```terminal
 root@rescue ~ # vgs
-  VG        #PV #LV #SN Attr   VSize    VFree  
+  VG        #PV #LV #SN Attr   VSize    VFree
   vg_system   1   8   0 wz--n- <442.94g <356.94g
 root@rescue ~ #
 ```
@@ -1035,7 +1036,7 @@ HTTP request sent, awaiting response... 200 OK
 Length: 76416 (75K) [application/x-debian-package]
 Saving to: ‘debootstrap_1.0.124_all.deb’
 
-debootstrap_1.0.124_all.deb                100%[=======================================================================================>]  74.62K  --.-KB/s    in 0.03s  
+debootstrap_1.0.124_all.deb                100%[=======================================================================================>]  74.62K  --.-KB/s    in 0.03s
 
 2021-08-22 12:42:35 (2.30 MB/s) - ‘debootstrap_1.0.124_all.deb’ saved [76416/76416]
 
@@ -1271,7 +1272,7 @@ Let’s update the cache .. :slightly_smiling_face:
 
 ```terminal
 root@rescue:/# apt-get update
-Fetched 22.9 MB in 3s (8565 kB/s)  
+Fetched 22.9 MB in 3s (8565 kB/s)
 [..]
 Reading package lists... Done
 Building dependency tree... Done
@@ -2061,7 +2062,7 @@ Installing `Fail2Ban` is best-practice with systems facing the internet directly
 ```terminal
 root@rescue:/# apt-get install -y fail2ban
 Reading package lists... Done
-Building dependency tree  
+Building dependency tree
 Reading state information... Done
 The following additional packages will be installed:
   python3-pyinotify python3-systemd whois

--- a/_posts/2023-05-08-ansible-apis-jinja2.md
+++ b/_posts/2023-05-08-ansible-apis-jinja2.md
@@ -1,6 +1,7 @@
 ---
 title: Automating APIs with Ansible .. and Jinja2
 author: Steffen Scheib
+last_modified_at: 2024-04-01
 ---
 ## Preface
 

--- a/_posts/2023-05-30-redhat-satellite-concept.md
+++ b/_posts/2023-05-30-redhat-satellite-concept.md
@@ -1,6 +1,7 @@
 ---
 title: A Red Hat Satellite 6 concept suggestion
 author: Steffen Scheib
+last_modified_at: 2024-03-11
 ---
 ## Preface
 

--- a/_posts/2023-06-21-ansible_automation_platform_promptable_promptable_job_templates.md
+++ b/_posts/2023-06-21-ansible_automation_platform_promptable_promptable_job_templates.md
@@ -1,6 +1,7 @@
 ---
 title: Ansible Automation Platform - Automating the execution of job templates and leveraging the 'prompt on launch' feature
 author: Steffen Scheib
+last_modified_at: 2024-03-09
 ---
 ## Introduction
 

--- a/_posts/2023-07-01-highly-customized-kickstart.md
+++ b/_posts/2023-07-01-highly-customized-kickstart.md
@@ -1,6 +1,7 @@
 ---
 title: Kickstarting Red Hat Enterprise Linux (RHEL) systems using a highly customized Kickstart with Red Hat Satellite 6
 author: Steffen Scheib
+last_modified_at: 2024-03-11
 ---
 ## Introduction
 

--- a/_posts/2023-07-09-automating-satellite.md
+++ b/_posts/2023-07-09-automating-satellite.md
@@ -1,6 +1,7 @@
 ---
 title: Automating Red Hat Satellite 6 - End to End
 author: Steffen Scheib
+last_modified_at: 2024-03-17
 ---
 <!-- markdownlint-disable MD033 -->
 {% raw %}

--- a/_posts/2023-08-28-debootstrapping-debian-bookworm.md
+++ b/_posts/2023-08-28-debootstrapping-debian-bookworm.md
@@ -1,6 +1,7 @@
 ---
 title: Manually installing Debian 12 (Bookworm) with fully encrypted LUKS (besides /boot) using debootstrap
 author: Steffen Scheib
+last_modified_at: 2024-04-01
 ---
 ## Introduction
 

--- a/_posts/2023-10-03-ansible-role-rhel_iso_kickstart.md
+++ b/_posts/2023-10-03-ansible-role-rhel_iso_kickstart.md
@@ -1,6 +1,7 @@
 ---
 title: Ansible role rhel_iso_kickstart
 author: Steffen Scheib
+last_modified_at: 2024-03-11
 ---
 ## Preface
 

--- a/_posts/2023-11-22-github-actions-ansible.md
+++ b/_posts/2023-11-22-github-actions-ansible.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started with testing Ansible code using Ansible Lint - with or without GitHub Actions
 author: Steffen Scheib
+last_modified_at: 2024-03-11
 ---
 ## Preface
 

--- a/_posts/2023-11-26-ansible-galaxy-publish-roles.md
+++ b/_posts/2023-11-26-ansible-galaxy-publish-roles.md
@@ -1,6 +1,7 @@
 ---
 title: Publishing roles to Ansible Galaxy - with or without GitHub Actions
 author: Steffen Scheib
+last_modified_at: 2024-03-10
 ---
 ## Preface
 

--- a/_posts/2024-02-17-execution-environments.md
+++ b/_posts/2024-02-17-execution-environments.md
@@ -1,6 +1,7 @@
 ---
 title: Execution Environments - From Zero to Hero. An in-depth explanation.
 author: Steffen Scheib
+last_modified_at: 2024-04-25
 ---
 ## Preface
 

--- a/_posts/2024-04-14-upgrade-raspberry-bullseye-bookworm.md
+++ b/_posts/2024-04-14-upgrade-raspberry-bullseye-bookworm.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrading Raspberry Pi OS 11 (Bullseye) to 12 (Bookworm)
 author: Steffen Scheib
+last_modified_at: 2024-04-15
 ---
 ## Preface
 


### PR DESCRIPTION
Removing jekyll-last-modified-at as the extension is no longer maintained.
With that introducing a last_modified_at frontmatter attribute to each post to build up the same functionality.
Further, adjusting the pyspelling configuration to ignore the attribute last_modified_at (similar to author and title).