### PR TITLE
fixing broken link to workflow documentation

### DIFF
--- a/_posts/2023-06-21-ansible_automation_platform_promptable_promptable_job_templates.md
+++ b/_posts/2023-06-21-ansible_automation_platform_promptable_promptable_job_templates.md
@@ -24,7 +24,7 @@ by the assigned [Instance Group](https://docs.ansible.com/automation-controller/
 Unfortunately, this recommendation did not work for the customer, because the requirement of the customer was, that their internal customers do not know where the servers are
 located and don't want to launch multiple job templates to achieve one simple task.
 
-Okay, so, but what about [Workflow Templates](https://docs.ansible.com/automation-controller/latest/html/userguide/workflows.html)? Still not good enough, because that
+Okay, so, but what about [Workflow Templates](https://docs.ansible.com/ansible-tower/latest/html/userguide/workflows.html)? Still not good enough, because that
 still would require multiple job templates to be set up to achieve the requirement of "1 Task, 1 Inventory, 1 Job Template".
 
 ## Ansible Automation Platform and the 'Prompt on launch' option

--- a/_posts/2023-06-21-ansible_automation_platform_promptable_promptable_job_templates.md
+++ b/_posts/2023-06-21-ansible_automation_platform_promptable_promptable_job_templates.md
@@ -18,8 +18,8 @@ This is no longer possible with Ansible Automation Platform 2.x, as the executio
 via SSH, but via [receptor](https://github.com/ansible/receptor) from a controller or hop node (through the [Automation Mesh](https://www.ansible.com/products/automation-mesh)).
 The most straight forward way to overcome this obstacle is to basically duplicate the job templates as many times as required, but each time assign a new instance group and the
 corresponding hosts to it. Either by specifying the `Limit` or creating a
-[Smart Inventory](https://docs.ansible.com/automation-controller/latest/html/userguide/inventories.html#smart-inventories) that would only contain the hosts that are reachable
-by the assigned [Instance Group](https://docs.ansible.com/automation-controller/latest/html/userguide/instance_groups.html).
+[Smart Inventory](https://docs.ansible.com/ansible-tower/latest/html/userguide/inventories.html#smart-inventories) that would only contain the hosts that are reachable
+by the assigned [Instance Group](https://docs.ansible.com/ansible-tower/latest/html/userguide/instance_groups.html).
 
 Unfortunately, this recommendation did not work for the customer, because the requirement of the customer was, that their internal customers do not know where the servers are
 located and don't want to launch multiple job templates to achieve one simple task.


### PR DESCRIPTION
The link to workflow documentation wasn't accessible at time of reading.
Updated it with the current working one.