### PR TITLE
ci: Fixing failing GitHub pages build

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-gems-
 
       - name: 'Deploy to GitHub Pages'
-        uses: 'jeffreytse/jekyll-deploy-action@v0.6.0'
+        uses: 'jeffreytse/jekyll-deploy-action@master'
         with:
           provider: 'github'
           token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Temporarily using master as version for the GitHub action jekyll-deploy-action due to a recently introduced change.
See: https://github.com/jeffreytse/jekyll-deploy-action/issues/98#issuecomment-2850033973